### PR TITLE
azure/upload_image.sh: fix stgaccountname for upload command

### DIFF
--- a/azure-flatcar-image-upload/upload_image.sh
+++ b/azure-flatcar-image-upload/upload_image.sh
@@ -128,7 +128,7 @@ bzip2 -d flatcar_production_azure_image.vhd.bz2
 # Upload image to Azure
 azure-vhd-utils upload \
 	--localvhdpath flatcar_production_azure_image.vhd \
-	--stgaccountname $RESOURCE_GROUP \
+	--stgaccountname $STORAGE_ACCOUNT_NAME \
 	--blobname $IMAGE_NAME \
 	--stgaccountkey "$KEY"
 


### PR DESCRIPTION
STORAGE_ACCOUNT_NAME should be used instead of RESOURCE_GROUP.

I missed that during testing, as I was using the same indentified for
both resource group and storage account name.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>