### PR TITLE
google-cloud-flatcar-image-upload: pin cloud SDK version

### DIFF
--- a/google-cloud-flatcar-image-upload/Dockerfile
+++ b/google-cloud-flatcar-image-upload/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:alpine
+FROM google/cloud-sdk:335.0.0-alpine
 
 COPY ./upload_image.sh /usr/local/bin/upload_images.sh
 


### PR DESCRIPTION
So built image can be reproduced and updates to SDK can be tracked.

Also updates SDK to latest version.

Closes #12.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>