### PR TITLE
update cloud-sdk to 401.0.0

### DIFF
--- a/google-cloud-flatcar-image-upload/Dockerfile
+++ b/google-cloud-flatcar-image-upload/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:335.0.0-alpine
+FROM google/cloud-sdk:401.0.0-alpine
 
 COPY ./upload_image.sh /usr/local/bin/upload_images.sh
 


### PR DESCRIPTION
Signed-off-by: Christian Hüning <christian.huening@finleap.com>

# Fix GCP Oauth2 error

* updates the cloud sdk to fix #14 

## How to use

as before

## Testing done

* updated the cloud-sdk
* tried the tool and it worked again
